### PR TITLE
Add outputType to exported function arguments

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -96,7 +96,7 @@ class Resizer {
         } else {responseUriFunc('File Not Found')}
     }
 }   
-export default { imageFileResizer: (file, maxWidth, maxHeight, compressFormat, quality, rotation, responseUriFunc) => {
-        return Resizer.createResizedImage(file, maxWidth, maxHeight, compressFormat, quality, rotation, responseUriFunc)
+export default { imageFileResizer: (file, maxWidth, maxHeight, compressFormat, quality, rotation, responseUriFunc, outputType) => {
+        return Resizer.createResizedImage(file, maxWidth, maxHeight, compressFormat, quality, rotation, responseUriFunc, outputType)
     } 
 }


### PR DESCRIPTION
Hello,

I think you forgot to add `outputType` to the exported function so I did.