### PR TITLE
Add support for "file" outputType

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Option | Description | Type | Required
 `quality` | A number between 0 and 100. Used for the JPEG compression.(if no compress is needed, just set it to 100) | `number` | Yes
 `rotation` | Degree of clockwise rotation to apply to the image. Rotation is limited to multiples of 90 degrees.(if no rotation is needed, just set it to 0) (0, 90, 180, 270, 360) | `number` | Yes
 `responseUriFunc` | Callback function of URI. Returns URI of resized image's base64 format. ex: `uri => {console.log(uri)});` | `function` | Yes
-`outputType` | Can be either base64 or blob.(Default type is base64) | `string` | No
+`outputType` | Can be either base64, blob or file.(Default type is base64) | `string` | No
 `minWidth` | New image min width (ratio is preserved, defaults to null) | `number` | No
 `minHeight` | New image min height (ratio is preserved, defaults to null) | `number` | No
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -21,6 +21,7 @@ declare module "react-image-file-resizer" {
     ): string;
 
     static b64toBlob(b64Data: string, contentType: string): Blob;
+    static b64toFile(b64Data: string, fileName: string, contentType: string): File;
 
     static createResizedImage(
       file: Blob,
@@ -30,7 +31,7 @@ declare module "react-image-file-resizer" {
       quality: number,
       rotation: number,
       responseUriFunc: (
-        value: string | Blob | ProgressEvent<FileReader>
+        value: string | Blob | File | ProgressEvent<FileReader>
       ) => void,
       outputType?: string,
       minWidth?: number,

--- a/src/index.js
+++ b/src/index.js
@@ -167,7 +167,7 @@ class Resizer {
                 responseUriFunc(file)
               break;
               default:
-                throw Error("Unknown outputType");
+                responseUriFunc(resizedDataUrl);
             }
           };
         };


### PR DESCRIPTION
Currently the module only support `blob` or `base64` for `outputType`.

This commit adds support for a 3rd option: `file` which will return a [File](https://developer.mozilla.org/en-US/docs/Web/API/File) JavaScript object.

This is useful for resizing images that are meant to be uploaded as files. 

*I.e. this can be used to send a file to a flask app that uses [`FileStorage`](https://tedboy.github.io/flask/generated/generated/werkzeug.FileStorage.html) class.*

Example: 

```javascript
const resizeFile = file => new Promise(resolve => {
    Resizer.imageFileResizer(file, 1000, 1000, "jpeg", 100, 0,
        file =>  resolve(file),
        "file"
    );
});
```

The returned `File` object will have the same name as the original image.

This also addresses some concerns such as issue #19 and #38 
