### PR TITLE
Fix bug "Uncaught TypeError: Cannot read property 'name' of undefined"

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -157,14 +157,14 @@ class Resizer {
             switch (outputType) {
               case "blob":
                 const blob = Resizer.b64toBlob(resizedDataUrl, contentType);
-                responseUriFunc(blob)
+                responseUriFunc(blob);
               break;
               case "base64":
                 responseUriFunc(resizedDataUrl);
               break;
               case "file":
-                const file = Resizer.b64toFile(resizedDataUrl, file.name, contentType);
-                responseUriFunc(file)
+                const newFile = Resizer.b64toFile(resizedDataUrl, file.name, contentType);
+                responseUriFunc(newFile);
               break;
               default:
                 responseUriFunc(resizedDataUrl);


### PR DESCRIPTION
Fixes a small bug that throws error `index.js:1 Uncaught TypeError: Cannot read property 'name' of undefined` when using the `file` outputType parameter.

This bug is happens because the variable `file` is being overwritten when creating a new file using `const file = new File(xxx)`
So just changing the name of this variable to something else to get rid of the error and to not overwrite the original file variable used in the code.