### PR TITLE
Update regular expression to ignore casensetive

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -164,7 +164,7 @@ class Resizer {
               break;
               case "file":
                 let fileName = file.name;
-                let fileNameWithoutFormat = fileName.toString().replace(/(png|jpeg|jpg|webp)/, "");
+                let fileNameWithoutFormat = fileName.toString().replace(/(png|jpeg|jpg|webp)$/i, "");
                 let newFileName = fileNameWithoutFormat.concat(compressFormat.toString());
                 const newFile = Resizer.b64toFile(resizedDataUrl, newFileName, contentType);
                 responseUriFunc(newFile);


### PR DESCRIPTION
Currently, it return a resize file with duplicate extension when input file extension is UPPERCASE.
Ex `hello.PNG` => `hello.PNGPNG`