### PR TITLE
Update transparency color to white when compressed

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -67,6 +67,8 @@ class Resizer {
     height = newHeightWidth.height;
 
     var ctx = canvas.getContext("2d");
+    ctx.fillStyle = "#fff";
+    ctx.fillRect(0, 0, width, height);
 
     if (rotation) {
       ctx.rotate((rotation * Math.PI) / 180);


### PR DESCRIPTION
When compressing a file format that contains transparency to a file format that doesn't support transparency, the transparent background is returned as black.

This change will return transparent backgrounds as white.