### PR TITLE
Set high image smoothing quality (solves bad resizing on Chrome)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -70,6 +70,10 @@ class Resizer {
     ctx.fillStyle = "rgba(0, 0, 0, 0)";
     ctx.fillRect(0, 0, width, height);
 
+    if (ctx.imageSmoothingEnabled && ctx.imageSmoothingQuality) {
+      ctx.imageSmoothingQuality = 'high';
+    }
+
     if (rotation) {
       ctx.rotate((rotation * Math.PI) / 180);
       if (rotation === 90) {


### PR DESCRIPTION
On Chrome, the default imageSmoothingQuality is `low` which results in some pretty bad blocky effects. If we set it to `high`, we get nicer resizes.

The before:
![resized](https://user-images.githubusercontent.com/192928/145523934-7f045eb3-abc6-49d6-b8ed-99f78bf229f1.jpg)

and after:
![resized_better](https://user-images.githubusercontent.com/192928/145523950-7506416f-cded-4c61-915c-a7689f604fa4.png)

