### PR TITLE
Match content type with file mime type

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -159,7 +159,7 @@ class Resizer {
               quality,
               rotation
             );
-            const contentType = `image/${compressFormat}`;
+            const contentType = file.type;
             switch (outputType) {
               case "blob":
                 const blob = Resizer.b64toBlob(resizedDataUrl, contentType);


### PR DESCRIPTION
Content Type served must be match with file Mime Type.
For example, if I've got a `*.jpg` image, Content Type must be `image/jpeg` (https://developer.mozilla.org/es/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types), not `image/jpg`.
This change, force to match with Mime Type always.